### PR TITLE
polaris: fstab: Remove duplicate `background_gc=off` options

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -9,7 +9,7 @@
 #<src>                                      <mnt_point>             <type>  <mnt_flags and options>                                                                           <fs_mgr_flags>
 system                                       /system                 ext4    ro,barrier=1                                                                                      wait,logical,first_stage_mount
 vendor                                       /vendor                 ext4    ro,barrier=1                                                                                      wait,logical,first_stage_mount
-/dev/block/bootdevice/by-name/userdata       /data                   f2fs    noatime,nosuid,nodev,discard,background_gc=off,fsync_mode=nobarrier                               latemount,wait,check,fileencryption=ice,quota,formattable,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata       /data                   f2fs    noatime,nosuid,nodev,discard,fsync_mode=nobarrier                               latemount,wait,check,fileencryption=ice,quota,formattable,reservedsize=128M
 /dev/block/bootdevice/by-name/userdata       /data                   ext4    noatime,nosuid,nodev,barrier=0,noauto_da_alloc                                                    latemount,wait,check,fileencryption=ice,quota
 /dev/block/bootdevice/by-name/modem          /vendor/firmware_mnt    vfat    ro,shortname=lower,uid=0,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0         wait
 /dev/block/bootdevice/by-name/dsp            /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1                                                                         wait


### PR DESCRIPTION
* In kernel commit 577c48de ("f2fs: implement rapid GC for Android") Removed BG_GC (background_gc=on) from default_options, It doesn't make sense to stay on fstab.qcom repeatedly.

Change-Id: I5b6806b24fa8d05577b4e3c8dc5c51c7f40e8680